### PR TITLE
feat: streams count api

### DIFF
--- a/packages/server/src/stream/stream.controller.ts
+++ b/packages/server/src/stream/stream.controller.ts
@@ -81,6 +81,19 @@ export class StreamController {
     );
   }
 
+  @Get('/:network/streams/count')
+  @ApiOkResponse({ type: BasicMessageDto })
+  async getStreamsCount(
+    @Param('network') network: Network,
+    @Query('modelStreamId') modelStreamId: string,
+  ): Promise<BasicMessageDto> {
+    const count = await this.streamService.getStreamsCount(
+      network,
+      modelStreamId,
+    );
+    return new BasicMessageDto('ok', 0, count);
+  }
+
   @Get('/:network/streams/topics')
   @ApiOkResponse({ type: BasicMessageDto })
   async getStreamTopics(

--- a/packages/server/src/stream/stream.controller.ts
+++ b/packages/server/src/stream/stream.controller.ts
@@ -85,11 +85,11 @@ export class StreamController {
   @ApiOkResponse({ type: BasicMessageDto })
   async getStreamsCount(
     @Param('network') network: Network,
-    @Query('modelStreamId') modelStreamId: string,
+    @Query('modelStreamIds') modelStreamIds: string,
   ): Promise<BasicMessageDto> {
     const count = await this.streamService.getStreamsCount(
       network,
-      modelStreamId,
+      modelStreamIds,
     );
     return new BasicMessageDto('ok', 0, count);
   }

--- a/packages/server/src/stream/stream.service.ts
+++ b/packages/server/src/stream/stream.service.ts
@@ -68,6 +68,21 @@ export default class StreamService {
       .getMany();
   }
 
+  async getStreamsCount(network: Network, modelStreamId: string) {
+    if (!modelStreamId || modelStreamId.trim().length == 0) return 0;
+    const ids = modelStreamId.split(',').map((id) => id.trim());
+    if (ids.length == 0) return 0;
+    const whereSql = `network=:network AND model IN (:...ids)`;
+    const count = await this.streamRepository
+      .createQueryBuilder()
+      .where(whereSql, {
+        network: network,
+        ids: ids,
+      })
+      .getCount();
+    return count;
+  }
+
   async getRelationStreamIds(
     ceramic: any,
     modelStreamId: string,
@@ -261,7 +276,7 @@ export default class StreamService {
           .orderBy('created_at', 'DESC')
           .getMany(),
         this.modelService.getModelStatistics(network),
-        this.streamRepository.count( {where: { network: network} } )
+        this.streamRepository.count({ where: { network: network } }),
       ]);
 
       console.timeEnd(`${network}-getStats`);

--- a/packages/server/src/stream/stream.service.ts
+++ b/packages/server/src/stream/stream.service.ts
@@ -68,9 +68,9 @@ export default class StreamService {
       .getMany();
   }
 
-  async getStreamsCount(network: Network, modelStreamId: string) {
-    if (!modelStreamId || modelStreamId.trim().length == 0) return 0;
-    const ids = modelStreamId.split(',').map((id) => id.trim());
+  async getStreamsCount(network: Network, modelStreamIds: string) {
+    if (!modelStreamIds || modelStreamIds.trim().length == 0) return 0;
+    const ids = modelStreamIds.split(',').map((id) => id.trim());
     if (ids.length == 0) return 0;
     const whereSql = `network=:network AND model IN (:...ids)`;
     const count = await this.streamRepository


### PR DESCRIPTION
![image](https://github.com/us3r-network/s3/assets/39647464/0d1afb26-b164-482a-aa2d-ae99a346c807)

1. models count （dapp 列表接口中有models数组）
2. composites count ( 已有接口可复用 /dapps/:dappId/composites )
3. streams count (新建工具接口  /:network/streams/count?modelStreamId=:id  其中:id 可以逗号分割)